### PR TITLE
Dpetev/coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,11 +4,13 @@
 /templates/**/*.js.map
 /lib/**/*.js.map
 /lib/**/*.js
-/spec/acceptance/**/*.js.map
-/spec/acceptance/**/*.js
+/spec/**/*.js.map
+/spec/**/*.js
 /templates/jquery/**/*.js
 !/templates/jquery/**/files/**/*
 /templates/angular/**/*.js
 !/templates/angular/**/files/**/*
 /templates/react/**/*.js
 !/templates/react/**/files/**/*
+/coverage
+/.nyc_output

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: node_js
 node_js:
 - '6'
+
+after_success: npm run coverage

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,8 +6,8 @@
 	"files.exclude": {
 		"lib/**/*.js.map": true,
 		"lib/**/*.js": {"when": "$(basename).ts"},
-		"spec/acceptance/**/*.js.map": true,
-		"spec/acceptance/**/*.js": {"when": "$(basename).ts"},
+		"spec/**/*.js.map": true,
+		"spec/**/*.js": {"when": "$(basename).ts"},
 		"templates/**/*.js.map": true,
 		"templates/**/*.js": {"when": "$(basename).ts"}
 	},

--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -13,7 +13,7 @@ import { Util } from "./Util";
 
 process.title = "Ignite UI CLI";
 
-export async function run() {
+export async function run(args = null) {
 	const templateManager = new TemplateManager();
 	// initialize all templates
 	templateManager.initializeTemplate();
@@ -22,7 +22,9 @@ export async function run() {
 	newCommand.builder.framework.choices = templateManager.getFrameworkIds();
 	add.templateManager = templateManager;
 
-	const argv = yargs.command(quickstart)
+	const yargsModule = args ? yargs(args) : yargs;
+
+	const argv = yargsModule.command(quickstart)
 	.command(start)
 	.command(newCommand)
 	.command(build)
@@ -36,7 +38,6 @@ export async function run() {
 		case "new":
 			await newCommand.execute(argv);
 			Util.log("Project Created");
-			process.exit();
 			break;
 		case "quickstart":
 			await quickstart.execute(argv);

--- a/package.json
+++ b/package.json
@@ -10,14 +10,16 @@
   "scripts": {
     "build": "node ./node_modules/typescript/lib/tsc.js",
     "pretest": "npm run lint && npm run build",
-    "test": "nyc --reporter=lcov --reporter=html npm run jasmine",
-    "jasmine": "node ./node_modules/jasmine-node/lib/jasmine-node/cli.js spec/",
-    "test-debug": "node --debug-brk=5858 ./node_modules/jasmine-node/lib/jasmine-node/cli.js spec/",
+    "test": "nyc npm run jasmine",
+	"jasmine": "jasmine spec/**/*.js",
+	"coverage": "nyc report --reporter=text-lcov | coveralls",
+    "test-debug": "node --debug-brk=5858 ./node_modules/jasmine/bin/jasmine.js spec/**/*.js",
     "lint": "tslint --project tsconfig.json"
   },
   "nyc": {
     "extension": [
-      ".ts"
+      ".ts",
+      ".tsx"
     ],
     "include": [
       "lib/",
@@ -27,6 +29,9 @@
       "**/*.d.ts",
       "templates/quickstart/",
       "templates/**/files/"
+    ],
+    "reporter": [
+      "lcov"
     ],
     "instrument": false,
     "all": true
@@ -47,7 +52,6 @@
     "through2": "^2.0.3",
     "yargs": "^8.0.2",
     "yargs-promise": "^1.1.0",
-    "jasmine-node": "^1.14.5",
     "typescript": "^2.5.3"
   },
   "devDependencies": {
@@ -56,6 +60,8 @@
     "@types/jasmine": "^2.5.54",
     "@types/node": "^8.0.5",
     "@types/shelljs": "^0.7.4",
+    "coveralls": "^3.0.0",
+    "jasmine": "^2.8.0",
     "nyc": "^11.3.0",
     "tslint": "^5.7.0"
   }

--- a/package.json
+++ b/package.json
@@ -8,11 +8,28 @@
   ],
   "main": "lib/cli.js",
   "scripts": {
-	"build": "node ./node_modules/typescript/lib/tsc.js",
-	"pretest": "npm run lint && npm run build",
-	"test": "node ./node_modules/jasmine-node/lib/jasmine-node/cli.js spec/",
-	"test-debug": "node --debug-brk=5858 ./node_modules/jasmine-node/lib/jasmine-node/cli.js spec/",
-	"lint": "tslint --project tsconfig.json"
+    "build": "node ./node_modules/typescript/lib/tsc.js",
+    "pretest": "npm run lint && npm run build",
+    "test": "nyc --reporter=lcov --reporter=html npm run jasmine",
+    "jasmine": "node ./node_modules/jasmine-node/lib/jasmine-node/cli.js spec/",
+    "test-debug": "node --debug-brk=5858 ./node_modules/jasmine-node/lib/jasmine-node/cli.js spec/",
+    "lint": "tslint --project tsconfig.json"
+  },
+  "nyc": {
+    "extension": [
+      ".ts"
+    ],
+    "include": [
+      "lib/",
+      "templates/"
+    ],
+    "exclude": [
+      "**/*.d.ts",
+      "templates/quickstart/",
+      "templates/**/files/"
+    ],
+    "instrument": false,
+    "all": true
   },
   "author": "PwnJS",
   "license": "ISC",
@@ -30,7 +47,7 @@
     "through2": "^2.0.3",
     "yargs": "^8.0.2",
     "yargs-promise": "^1.1.0",
-	"jasmine-node": "^1.14.5",
+    "jasmine-node": "^1.14.5",
     "typescript": "^2.5.3"
   },
   "devDependencies": {
@@ -39,6 +56,7 @@
     "@types/jasmine": "^2.5.54",
     "@types/node": "^8.0.5",
     "@types/shelljs": "^0.7.4",
+    "nyc": "^11.3.0",
     "tslint": "^5.7.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "build": "node ./node_modules/typescript/lib/tsc.js",
     "pretest": "npm run lint && npm run build",
     "test": "nyc npm run jasmine",
-	"jasmine": "jasmine spec/**/*.js",
-	"coverage": "nyc report --reporter=text-lcov | coveralls",
+    "jasmine": "jasmine spec/**/*.js",
+    "coverage": "nyc report --reporter=text-lcov | coveralls",
     "test-debug": "node --debug-brk=5858 ./node_modules/jasmine/bin/jasmine.js spec/**/*.js",
     "lint": "tslint --project tsconfig.json"
   },
@@ -27,13 +27,19 @@
     ],
     "exclude": [
       "**/*.d.ts",
+      "output/",
       "templates/quickstart/",
       "templates/**/files/"
     ],
     "reporter": [
-      "lcov"
+      "lcov",
+      "text-summary"
     ],
-    "instrument": false,
+    "require": [
+      "ts-node/register"
+    ],
+    "instrument": true,
+    "cache": false,
     "all": true
   },
   "author": "PwnJS",
@@ -63,6 +69,8 @@
     "coveralls": "^3.0.0",
     "jasmine": "^2.8.0",
     "nyc": "^11.3.0",
+    "source-map-support": "^0.5.0",
+    "ts-node": "^3.3.0",
     "tslint": "^5.7.0"
   }
 }

--- a/spec/acceptance/new-spec.ts
+++ b/spec/acceptance/new-spec.ts
@@ -1,18 +1,17 @@
 import * as fs from "fs";
+import cli = require("../../lib/cli");
 describe("New", () => {
 
-	// tslint:disable-next-line:only-arrow-functions
-	it("React project", async function(done) {
+	it("React project", async done => {
 		process.chdir("./output");
-		process.argv = ["node", "cli", "new", "reactProj", "--framework=react"];
-
-		const cli = require("../../lib/cli");
+		// process.argv = ["new", "reactProj", "--framework=react"];
 
 		// this isn't really going to wait.. TODO
-		await cli.run();
+		await cli.run(["new", "reactProj", "--framework=react"]);
 
 		//TODO: read entire structure from ./templates and verify everything is copied over
 		expect(fs.existsSync("./reactProj")).toBeTruthy();
+		process.chdir("../");
 		done();
 	});
 

--- a/spec/templates/jquery-spec.ts
+++ b/spec/templates/jquery-spec.ts
@@ -7,8 +7,6 @@ describe("New", () => {
 		expect(jQueryFramework.projectLibraries[0]).toBeDefined();
 
 		for (const template of jQueryFramework.projectLibraries[0].templates) {
-			// tslint:disable-next-line:no-console
-			console.log("checking", template.name);
 			expect(template.id).toBeDefined("No ID: " + template.name);
 		}
 		done();

--- a/spec/templates/jquery-spec.ts
+++ b/spec/templates/jquery-spec.ts
@@ -1,0 +1,17 @@
+
+describe("New", () => {
+
+	// tslint:disable-next-line:only-arrow-functions
+	it("jQuery js templates should have IDs", async function(done) {
+		const jQueryFramework = require("../../templates/jquery");
+		expect(jQueryFramework.projectLibraries[0]).toBeDefined();
+
+		for (const template of jQueryFramework.projectLibraries[0].templates) {
+			// tslint:disable-next-line:no-console
+			console.log("checking", template.name);
+			expect(template.id).toBeDefined("No ID: " + template.name);
+		}
+		done();
+	});
+
+});

--- a/templates/react/es6/projects/empty/index.ts
+++ b/templates/react/es6/projects/empty/index.ts
@@ -22,7 +22,7 @@ class EmptyProject implements ProjectTemplate {
 		configFile = configFile.replace(`"ignite-ui/js/infragistics.lob.js$"`, `//$&`);
 		fs.writeFileSync(filePath, configFile);
 	}
-	public generateFiles(outputPath: string, name: string, theme: string, ...options: any[]): Promise<boolean> {
+	public async generateFiles(outputPath: string, name: string, theme: string, ...options: any[]): Promise<boolean> {
 
 		//TODO update the config with [{key: "keyname", "value"}]
 		const config = {


### PR DESCRIPTION
~Coverage currently won't show untouched files, but that will soon improve with tests (will tap most files once).
Forcing `--all` requires `instrument` as well, which produces either incorrect reports on nothing at all, so I've given up on trying to make it work for now.~
Damn cache is a cruel mistress. Coverage looks good now, so closing #51 .. maybe?