### PR TITLE
fix(npm): add registry URL trailing slash, required for npm 5.5.1+

### DIFF
--- a/lib/packages/PackageManager.ts
+++ b/lib/packages/PackageManager.ts
@@ -11,7 +11,7 @@ import componentsConfig = require("./components");
 export class PackageManager {
 	private static ossPackage: string = "ignite-ui";
 	private static fullPackage: string = "@infragistics/ignite-ui-full";
-	private static fullPackageRegistry: string = "https://packages.infragistics.com/npm/js-licensed";
+	private static fullPackageRegistry: string = "https://packages.infragistics.com/npm/js-licensed/";
 
 	/**
 	 * Specific for Ignite UI packages handling:


### PR DESCRIPTION
[skip ci]